### PR TITLE
Fix: 1 security vulnerabilities in cmsdetect.py

### DIFF
--- a/Plugins/cmsdetect.py
+++ b/Plugins/cmsdetect.py
@@ -1,7 +1,11 @@
+import os
 import requests
 
 def CMSdetect(domain, port):
-    payload = {'key': '1641c3b9f2b1c8676ceaba95d00f7cf2e3531830c5fa9a6cc5e2d922b2ed7165dcce66', 'url': domain}
+    api_key = os.getenv('WHATCMS_API_KEY')
+    if not api_key:
+        raise ValueError('API key for WhatCMS not found in environment variable WHATCMS_API_KEY')
+    payload = {'key': api_key, 'url': domain}
     cms_url = "https://whatcms.org/APIEndpoint/Detect"
     response = requests.get(cms_url, params=payload)
     cms_data = response.json()


### PR DESCRIPTION
## Security Fixes\n\nThis PR fixes 1 security vulnerabilities:\n\n- **vuln_3f5971797d6d4f94ba388dde20c11d1f**: Removed the hardcoded API key from the payload dictionary. Instead, retrieve the API key securely from the environment variable 'WHATCMS_API_KEY'. Added a check to raise an error if the environment variable is not set, ensuring the API key is managed securely and not exposed in the source code.\n\n---\n*Generated by [ByteArmor](https://bytearmor.ai)*